### PR TITLE
First pass at making it easier to get started

### DIFF
--- a/agagd/agagd/settings/__init__.py
+++ b/agagd/agagd/settings/__init__.py
@@ -1,0 +1,5 @@
+# local_settings not required, but makes for a friendlier way to set stage
+try:
+    from local_settings import *
+except ImportError:
+    pass

--- a/agagd/agagd/settings/base.py
+++ b/agagd/agagd/settings/base.py
@@ -1,7 +1,7 @@
-#!/bin/env python
-# Django settings for agagd project.
 import django.conf.global_settings as DEFAULT_SETTINGS
-import os, getpass
+import os
+
+PROJECT_ROOT = os.environ['PROJECT_ROOT']
 
 ADMINS = (
     ('Andrew Jackson', 'operations@usgo.org'),
@@ -53,10 +53,7 @@ STATIC_URL = '/static/'
 
 # Additional locations of static files
 STATICFILES_DIRS = (
-    # Put strings here, like "/home/html/static" or "C:/www/django/static".
-    # Always use forward slashes, even on Windows.
-    # Don't forget to use absolute paths, not relative paths.
-    '/Users/andrew/work/agagd_project/agagd/static', 
+    os.path.join(PROJECT_ROOT, 'static'), 
 )
 
 # List of finder classes that know how to find static files in
@@ -75,6 +72,10 @@ TEMPLATE_LOADERS = (
 #     'django.template.loaders.eggs.Loader',
 )
 
+TEMPLATE_DIRS = (
+    os.path.join(PROJECT_ROOT, 'templates'),
+)
+
 MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -89,12 +90,6 @@ ROOT_URLCONF = 'agagd.urls'
 
 # Python dotted path to the WSGI application used by Django's runserver.
 WSGI_APPLICATION = 'agagd.wsgi.application'
-
-TEMPLATE_DIRS = [
-    # Put strings here, like "/home/html/django_templates" or "C:/www/django/templates".
-    # Always use forward slashes, even on Windows.
-    # Don't forget to use absolute paths, not relative paths.  
-]
 
 TEMPLATE_CONTEXT_PROCESSORS = DEFAULT_SETTINGS.TEMPLATE_CONTEXT_PROCESSORS + (
     'django.core.context_processors.request',

--- a/agagd/agagd/settings/dev.py
+++ b/agagd/agagd/settings/dev.py
@@ -1,6 +1,5 @@
-#!/bin/env python
-
 from base import *
+import getpass
 
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
@@ -11,11 +10,7 @@ INSTALLED_APPS += ('django.contrib.admin',)
 EMAIL_HOST = 'localhost'
 EMAIL_PORT = 1025
 
-try:
-    _password = os.environ['MYSQL_PASS']
-except KeyError:
-    _password = getpass.getpass('Mysql password >')
-    os.environ['MYSQL_PASS'] = _password
+_password = os.environ.get('MYSQL_PASS', '')
 
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = '#-+^ipw3x)1dq0$v*z0_^tzoxzcwz3s8^x8kd^5s9+9tfwuixv'
@@ -30,5 +25,3 @@ DATABASES = {
         'PORT': '',                      # Set to empty string for default. Not used with sqlite3.
     }
 }
-
-TEMPLATE_DIRS = ('/Users/andrew/work/agagd_project/agagd/templates', )

--- a/agagd/agagd_core/models.py
+++ b/agagd/agagd_core/models.py
@@ -16,7 +16,7 @@ class Members(models.Model):
         verbose_name = u'member'
         verbose_name_plural = u'members'
 
-    member_id = models.TextField(primary_key=True, editable=False) # This field type is a guess.
+    member_id = models.CharField(max_length=255, primary_key=True, editable=False) # This field type is a guess.
     legacy_id = models.TextField(blank=True) # This field type is a guess.
     full_name = models.CharField(max_length=255, blank=True)
     given_names = models.CharField(max_length=255, blank=True)
@@ -42,7 +42,7 @@ class Chapter(models.Model):
         db_table = u'chapter'
 
 class Chapters(models.Model):
-    member_id = models.TextField(primary_key=True) # This field type is a guess.
+    member_id = models.CharField(max_length=255, primary_key=True) # This field type is a guess.
     name = models.CharField(max_length=255, blank=True)
     legacy_status = models.CharField(max_length=1, blank=True)
     code = models.CharField(max_length=4, blank=True)
@@ -161,7 +161,7 @@ class Ratings(models.Model):
         managed = False
 
 class MembersRegions(models.Model):
-    region_id = models.TextField(primary_key=True) # This field type is a guess.
+    region_id = models.CharField(max_length=255, primary_key=True) # This field type is a guess.
     region = models.CharField(max_length=255, blank=True)
     states = models.CharField(max_length=255, blank=True)
     class Meta:

--- a/agagd/local_settings.py.sample
+++ b/agagd/local_settings.py.sample
@@ -1,0 +1,12 @@
+from agagd.settings.dev import *
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': '',         # database name
+        'USER': '',
+        'PASSWORD': '',
+        'HOST': '',         # blank means localhost
+        'PORT': '',         # blank means default mysql port (3306)
+    }
+}

--- a/agagd/manage.py
+++ b/agagd/manage.py
@@ -3,6 +3,7 @@ import os
 import sys
 
 if __name__ == "__main__":
+    os.environ.setdefault('PROJECT_ROOT', os.getcwd())
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "agagd.settings")
 
     from django.core.management import execute_from_command_line

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -11,16 +11,28 @@ A port of the old eurogo Games Database to python, for the AGA
 
 ### Getting started
 
-Virtualenv and virtualenvwrapper are recommended.  It should be as easy as:
+The first step is to install `mysql` and create an `agagd` database.
+
+Virtualenv and virtualenvwrapper are recommended.
 
 ~~~
-$ workon agagd # set up the virtualenv
-$ pip install django django-admin-tools
+$ mkvirtualenv agagd
+$ workon agagd 
+$ cd PATH_TO_REPO_ROOT
+$ pip install -r requirements_dev.txt
+$ cd agagd/
+$ cp local_settings.py.sample local_settings.py
+~~~
 
-[ ... monkey about with db settings ... ]
+Edit your `local_settings.py` to match your database settings.
 
+~~~
+$ python manage.py syncdb
+$ # python manage.py loaddata NONEXISTENT_FIXTURE - TODO
 $ python manage.py runserver
 ~~~
+
+After the above, you should be able to see the site up and running at http://localhost:8000
 
 ### development needs
 1. It'd really help if we had a sanitized version of the database we could use,

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+ipython


### PR DESCRIPTION
The steps are documented on docs/readme.md.

I'm not sure how prod actually looks so I tried not to break it.  However it was configured before on both stages should still work (i.e. via environment variables).

This commit makes it so you don't need to set any environment variables and can use `local_settings.py` (which was in `.gitignore` for some reason - I couldn't find any references to it).  The reason for wanting `local_settings.py` was that it seemed like a more straightforward way for someone to get started.

Also in the commit are the fixes to models which allows `syncdb` to work.  That part probably still needs more work since I just guessed the mysql schema on top of django's guesses.
