### PR TITLE
removed a # tag in a command line from 'getting started'

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -30,7 +30,7 @@ Edit your `local_settings.py` to match your database settings.  If you are using
 
 ~~~
 $ python manage.py syncdb --noinput
-$ # python manage.py loaddata fake_data
+$ python manage.py loaddata fake_data
 $ python manage.py runserver
 ~~~
 


### PR DESCRIPTION
Corrected "getting started" command
