### PR TITLE
Use the same cell highlight color for all winners

### DIFF
--- a/agagd/static/css/tables.css
+++ b/agagd/static/css/tables.css
@@ -118,10 +118,7 @@ table.paleblue > tbody > tr > td > span.false {
     width: 10px;
 }
 
-table.paleblue > tbody > tr.even > td.winner {
-    background-color: #DDF3DE;
-}
-table.paleblue > tbody > tr.odd > td.winner {
+table.paleblue > tbody > tr > td.winner {
     background-color: #CDF3CE;
 }
 


### PR DESCRIPTION
Regardless of zebra striping.  Mo' colors = mo' confusion :)

Before
-------

![before](https://cloud.githubusercontent.com/assets/380809/5607244/1ef040b0-9421-11e4-92d9-01da193a7a61.jpg)

After
------

![after](https://cloud.githubusercontent.com/assets/380809/5607245/21459644-9421-11e4-9e83-ba27bc9891de.jpg)

