### PR TITLE
Fix for missing graph for some players

### DIFF
--- a/agagd/agagd_core/views/core.py
+++ b/agagd/agagd_core/views/core.py
@@ -61,11 +61,11 @@ def member_ratings(request, member_id):
              'rating': r.rating} for r in ratings
             if r.elab_date != None]
         if len(ratings_dict) <= 1: 
-            logger.error('Ratings error: only one rating')
+            logger.debug('Ratings error: only one rating')
             return JsonResponse({'result': 'error'})
         return JsonResponse(ratings_dict) 
     except:
-        logger.error('Ratings error', exc_info=1)
+        logger.debug('Ratings error', exc_info=1)
         return JsonResponse({'result':'error'})
 
 def member_detail(request, member_id):


### PR DESCRIPTION
The player rating graph doesn't handle null dates gracefully (ie, it crashes).  I added some code to the view that renders the ratings json to filter out ratings entries with null elab_date on the server to ensure that the graph to render for those players anyway.

Issues with data integrity will be deferred for future conversations.

Fixes #43 