### PR TITLE
Update requirements and setup instructions

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -11,11 +11,21 @@ A port of the old eurogo Games Database to python, for the AGA
 
 ### Getting started
 
-The first optional step is to install `mysql` and create an `agagd` database.
+**NB: agagd is no longer compatible with sqlite3; as of 2020-02-01, it requires features only available in MySQL.**
 
-The other option is to use sqlite3.  This option doesn't require you to do anything extra.
+**NB: running the agagd locally now requires access to a database schema not provided by this repository.**
 
-Virtualenv and virtualenvwrapper are recommended.
+The first step is to install `mysql` and create an `agagd` database. Then load the current database schema snapshot, as well
+as the SQL files in `sql/`, into the `agagd` database, e.g.:
+
+~~~
+mysql agagd < schema.sql
+for file in sql/*; do
+  mysql agagd < $file
+done
+~~~
+
+Next set up the app environment. Virtualenv and virtualenvwrapper are recommended.
 
 ~~~
 $ mkvirtualenv agagd
@@ -26,10 +36,9 @@ $ cd agagd/
 $ cp local_settings.py.sample local_settings.py
 ~~~
 
-Edit your `local_settings.py` to match your database settings.  If you are using sqlite3, you don't need to change anything.
+Edit your `local_settings.py` to match your database settings.
 
 ~~~
-$ python manage.py syncdb --noinput
 $ python manage.py loaddata fake_data
 $ python manage.py runserver
 ~~~

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -11,18 +11,18 @@ A port of the old eurogo Games Database to python, for the AGA
 
 ### Getting started
 
-**NB: agagd is no longer compatible with sqlite3; as of 2020-02-01, it requires features only available in MySQL.**
+**Important: agagd is no longer compatible with sqlite3; as of 2020-02-01, it requires features only available in MySQL.**
 
-**NB: running the agagd locally now requires access to a database schema not provided by this repository.**
+**Important: running the agagd locally now requires access to a database schema not provided by this repository.**
 
 The first step is to install `mysql` and create an `agagd` database. Then load the current database schema snapshot, as well
 as the SQL files in `sql/`, into the `agagd` database, e.g.:
 
 ~~~
-mysql agagd < schema.sql
-for file in sql/*; do
-  mysql agagd < $file
-done
+$ mysql agagd < schema.sql
+$ for file in sql/*; do
+$   mysql agagd < $file
+$ done
 ~~~
 
 Next set up the app environment. Virtualenv and virtualenvwrapper are recommended.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ Django==1.6.11
 django-admin-tools==0.4.1
 django-tables2==0.14.0
 mysqlclient==1.4.6
-pysqlite==2.6.3
 requests==2.22.0
 six==1.4.1
 wsgiref==0.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
-Django==1.5.4
-MySQL-python==1.2.4
+Django==1.6.11
 django-admin-tools==0.4.1
 django-tables2==0.14.0
+mysqlclient==1.4.6
 pysqlite==2.6.3
+requests==2.22.0
 six==1.4.1
 wsgiref==0.1.2
 yolk==0.4.3


### PR DESCRIPTION
Updated documentation to reflect dependence on an external DB schema that has drifted significantly from what `syncdb` produces.

Replaced MySQLdb with mysqlclient. The former is deprecated - it can no longer
even be installed via 'pip'. Unfortunately, django 1.5.x relies on undocumented
behavior that was not quite duplicated exactly in mysqlclient, which introduces
a bug. Upgrading to Django 1.6.x fixes the resulting bug.

If upgrading to django 1.6 feels too risky, an alternative approach would be to download the MySQLdb module and check it in to git, and add instructions to install it locally. In general, however, I'd suggest that it is a good idea to start upgrading the django version - 1.5 has not been receiving security bugfixes since 2014. (the django docs recommend upgrading through one minor release at a time, so a larger jump is not advised)

**The django 1.6 update DOES include backwards-incompatible changes, listed here: https://docs.djangoproject.com/en/3.0/releases/1.6/#backwards-incompatible-changes-in-1-6**. As far as I've been able to determine, none of the breaking changes should apply to AGAGD, however, someone more familiar with the application should definitely verify that.