### PR TITLE
Remove unused 'Chapter' model

### DIFF
--- a/agagd/agagd_core/admin.py
+++ b/agagd/agagd_core/admin.py
@@ -1,10 +1,9 @@
-from agagd_core.models import Chapter, Chapters, Country, Game, Member, MembersRegions, Membership
+from agagd_core.models import Chapters, Country, Game, Member, MembersRegions, Membership
 from django.contrib import admin
 
 class MemberAdmin(admin.ModelAdmin): 
     list_display = ('member_id', 'full_name', 'join_date', 'chapter', 'chapter_id')
 
-admin.site.register(Chapter)
 admin.site.register(Chapters)
 admin.site.register(Country)
 admin.site.register(Game)

--- a/agagd/agagd_core/models.py
+++ b/agagd/agagd_core/models.py
@@ -39,14 +39,6 @@ class Member(models.Model):
         verbose_name_plural = 'members'
         managed = False
 
-class Chapter(models.Model):
-    chapter_code = models.CharField(max_length=4, primary_key=True, db_column='Chapter_Code')
-    chapter_descr = models.CharField(max_length=50, db_column='Chapter_Descr')
-
-    class Meta:
-        db_table = 'chapter'
-        managed = False
-
 class Chapters(models.Model):
     member_id = models.ForeignKey(Member, db_column='member_id', primary_key=True)
     name = models.CharField(max_length=255, blank=True)


### PR DESCRIPTION
This is not to be confused with the widely used 'Chapters' model. The `Chapter` model only has 2 fields and does not appear to be used for anything.

Fixes #126 