### PR TITLE
Remove redundant 'chapter' field from the chapter detail view.

### DIFF
--- a/agagd/agagd_core/tables.py
+++ b/agagd/agagd_core/tables.py
@@ -98,27 +98,20 @@ class MemberTable(tables.Table):
         kwargs={'member_id': tables.A('member_id')})
 
     def render_chapter_id(self, value):
-        try:
-            members_chapter = Chapters.objects.get(member_id=value)
-
-            chapter_url = reverse(
-                viewname='chapter_detail',
-                kwargs={'chapter_id': value})
-
-            chapter_name = members_chapter.name
-            if chapter_name is None or chapter_name == "":
-                chapter_name = members_chapter.code
-
-            chapter_html = mark_safe("<a href='{}'>{}</a>".format(chapter_url, chapter_name))
-        except:
-            chapter_html = u"\u2014"
-        return chapter_html
+        render_chapter_link_from_id(value)
 
     class Meta:
         model = Member
         attrs = {"class": "paleblue"}
         fields = ('full_name', 'state', 'players__rating', 'renewal_due', 'country')
         sequence = ('full_name', 'players__rating', 'chapter_id', 'country', 'state', 'renewal_due', 'member_id')
+
+class ChapterMemberTable(MemberTable):
+    class Meta:
+        model = Member
+        attrs = {"class": "paleblue"}
+        fields = ('full_name', 'state', 'players__rating', 'renewal_due', 'country')
+        sequence = ('full_name', 'players__rating', 'country', 'state', 'renewal_due', 'member_id')
 
 class TopDanTable(tables.Table):
     member_id = tables.LinkColumn(
@@ -196,21 +189,7 @@ class AllPlayerRatingsTable(tables.Table):
     )
 
     def render_chapter_id(self, value):
-        try:
-            members_chapter = Chapters.objects.get(member_id=value)
-
-            chapter_url = reverse(
-                viewname='chapter_detail',
-                kwargs={'chapter_id': value})
-
-            chapter_name = members_chapter.name
-            if chapter_name is None or chapter_name == "":
-                chapter_name = members_chapter.code
-
-            chapter_html = mark_safe("<a href='{}'>{}</a>".format(chapter_url, chapter_name))
-        except:
-            chapter_html = u"\u2014"
-        return chapter_html
+        render_chapter_link_from_id(value)
 
     class Meta:
         attrs = {"class": "paleblue"}
@@ -247,3 +226,22 @@ class TournamentPlayedTable(tables.Table):
 
     class Meta:
         attrs = {"class": "paleblue"}
+
+# Takes a chapter ID and produces an href with the chapter's name
+def render_chapter_link_from_id(value):
+    try:
+        members_chapter = Chapters.objects.get(member_id=value)
+
+        chapter_url = reverse(
+            viewname='chapter_detail',
+            kwargs={'chapter_id': value})
+
+        chapter_name = members_chapter.name
+        if chapter_name is None or chapter_name == "":
+            chapter_name = members_chapter.code
+
+        chapter_html = mark_safe("<a href='{}'>{}</a>".format(chapter_url, chapter_name))
+    except:
+        chapter_html = u"\u2014"
+
+    return chapter_html

--- a/agagd/agagd_core/views/core.py
+++ b/agagd/agagd_core/views/core.py
@@ -1,7 +1,7 @@
 from agagd_core.json_response import JsonResponse
 from agagd_core.models import Game, Member, Tournament, TopDan, TopKyu, MostRatedGamesPastYear, MostTournamentsPastYear, Chapters, Country
-from agagd_core.tables import GameTable, GameTable2, MemberTable, TournamentTable, TopDanTable, TopKyuTable, OpponentTable, TournamentPlayedTable
-from agagd_core.tables import AllPlayerRatingsTable, MostRatedGamesPastYearTable, MostTournamentsPastYearTable
+from agagd_core.tables import GameTable, GameTable2, MemberTable, ChapterMemberTable, TournamentTable, OpponentTable, TournamentPlayedTable
+from agagd_core.tables import TopDanTable, TopKyuTable, AllPlayerRatingsTable, MostRatedGamesPastYearTable, MostTournamentsPastYearTable
 from datetime import datetime, timedelta, date
 from django.core import exceptions
 from django.core.paginator import PageNotAnInteger
@@ -224,10 +224,10 @@ def tournament_detail(request, tourn_code):
 
 def chapter_detail(request, chapter_id):
     chapter = get_object_or_404(Chapters, member_id=chapter_id)
-    member_table = MemberTable(Member.objects.filter(chapter_id=chapter_id).order_by('family_name') )
+    chapter_member_table = ChapterMemberTable(Member.objects.filter(chapter_id=chapter_id).order_by('family_name') )
     return render(request, 'agagd_core/chapter.html',
             {
-                'member_table': member_table,
+                'member_table': chapter_member_table,
                 'chapter': chapter,
             })
 


### PR DESCRIPTION
* Remove the chapter column from the chapter page, since it is redundant.
* Refactor the duplicate `render_chapter_id` functions into a single function.