### PR TITLE
Correct ratings_set as it should players.

### DIFF
--- a/agagd/agagd_core/views/core.py
+++ b/agagd/agagd_core/views/core.py
@@ -256,7 +256,7 @@ def all_player_ratings(request):
     ).filter(
         status='accepted'
     ).exclude(
-        ratings_set__rating__isnull=True
+        players__rating__isnull=True
     ).exclude(
         type='chapter'
     ).exclude(


### PR DESCRIPTION
## Summary
Small change that moves `ratings_set` to players table as players is used thoughout all_player_ratings.