### PR TITLE
add player list without django tables2

### DIFF
--- a/agagd/agagd/urls.py
+++ b/agagd/agagd/urls.py
@@ -59,5 +59,5 @@ urlpatterns = (
     path("information/", InformationPageView.as_view()),
     path("qualifications/", QualificationsPageView.as_view()),
     # Beta
-    url(r"^beta/", include("agagd_core.urls")),
+    path("beta/", include("agagd_core_urls.beta_urlpatterns")),
 )

--- a/agagd/agagd/urls.py
+++ b/agagd/agagd/urls.py
@@ -1,3 +1,4 @@
+from agagd_core import urls as beta_urls
 from agagd_core import views as agagd_views
 from agagd_core.views import InformationPageView, QualificationsPageView
 from django.conf import settings
@@ -59,5 +60,5 @@ urlpatterns = (
     path("information/", InformationPageView.as_view()),
     path("qualifications/", QualificationsPageView.as_view()),
     # Beta
-    path("beta/", include("agagd_core_urls.beta_urlpatterns")),
+    path("beta/", include(beta_urls.beta_patterns)),
 )

--- a/agagd/agagd_core/models.py
+++ b/agagd/agagd_core/models.py
@@ -44,7 +44,12 @@ class Member(models.Model):
 class Chapters(models.Model):
     # The member_id for a chapter is the same in this table and in the chapter's corresponding Member object.
     member_id = models.ForeignKey(
-        Member, db_column="member_id", primary_key=True, on_delete=models.DO_NOTHING
+        "Member",
+        db_column="member_id",
+        to_field="chapter_id",
+        unique=True,
+        primary_key=True,
+        on_delete=models.DO_NOTHING,
     )
 
     name = models.CharField(max_length=255, blank=True)

--- a/agagd/agagd_core/urls.py
+++ b/agagd/agagd_core/urls.py
@@ -1,10 +1,9 @@
-from agagd_core.views import beta as agagd_beta_views
+from agagd_core.views import beta
 from django.urls import path
 
-beta_urlpatterns = (
-    [
-        path("", agagd_beta_views.index, name="index"),
-        path("players/", agagd_beta_views.list_all_players, name="players_list"),
-    ],
-    "beta",
-)
+# Note: Based of request for single qoutes.
+# fmt: off
+beta_patterns = ([
+        path('', beta.index, name='index'),
+        path('players/', beta.list_all_players, name='players_list'),
+    ], 'beta')

--- a/agagd/agagd_core/urls.py
+++ b/agagd/agagd_core/urls.py
@@ -1,4 +1,10 @@
 from agagd_core.views import beta as agagd_beta_views
-from django.conf.urls import url
+from django.urls import path
 
-urlpatterns = (url(r"$", agagd_beta_views.index),)
+beta_urlpatterns = (
+    [
+        path("", agagd_beta_views.index, name="index"),
+        path("players/", agagd_beta_views.list_all_players, name="players_list"),
+    ],
+    "beta",
+)

--- a/agagd/agagd_core/views/beta.py
+++ b/agagd/agagd_core/views/beta.py
@@ -91,13 +91,16 @@ def list_all_players(request):
         )
         .order_by("-players__rating")
     )
+
+    mobile_column_attrs = "d-none d-lg-table-cell d-xl-table-cell"
+
     list_all_players_columns = (
         {"name": "Name", "attrs": None},
         {"name": "Chapter", "attrs": None},
-        {"name": "State", "attrs": None},
-        {"name": "Type", "attrs": None},
+        {"name": "State", "attrs": mobile_column_attrs},
+        {"name": "Type", "attrs": mobile_column_attrs},
         {"name": "Rating", "attrs": None},
-        {"name": "Sigma", "attrs": None},
+        {"name": "Sigma", "attrs": mobile_column_attrs},
     )
 
     list_all_players_with_pagination = agagd_paginator_helper(
@@ -108,6 +111,7 @@ def list_all_players(request):
         request,
         "agagd_core/players_list.html",
         {
+            "mobile_column_attrs": mobile_column_attrs,
             "list_all_players_columns": list_all_players_columns,
             "list_all_players_data": list_all_players_with_pagination,
             "page_title": "Members Ratings",

--- a/agagd/agagd_core/views/beta.py
+++ b/agagd/agagd_core/views/beta.py
@@ -8,10 +8,29 @@ import agagd_core.models as agagd_models
 import agagd_core.tables.beta as agagd_tables
 
 # Django Imports
+from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
+from django.db.models import F, Prefetch, Q
 from django.shortcuts import get_object_or_404, redirect, render
 
 # Django Table Imports
 from django_tables2 import RequestConfig
+
+
+def agagd_paginator_helper(
+    request, query_list_object, max_rows_per_page=50, page_request_get_value="pg"
+):
+    paginator = Paginator(query_list_object, max_rows_per_page)
+
+    page_number = request.GET.get(page_request_get_value, 1)
+
+    try:
+        query_list_object_with_page_information = paginator.page(page_number)
+    except PageNotAnInteger:
+        query_list_object_with_page_information = paginator.page(1)
+    except EmptyPage:
+        query_list_object_with_page_information = paginator.page(paginator.num_pages)
+
+    return query_list_object_with_page_information
 
 
 def index(request):
@@ -46,5 +65,51 @@ def index(request):
             "most_rated_games_table": mostRatedGamesTable,
             "most_tournaments_table": mostTournamentsPastYearTable,
             "tournaments": t_table,
+        },
+    )
+
+
+def list_all_players(request):
+    list_all_players_query = (
+        agagd_models.Member.objects.select_related("chapters")
+        .filter(status="accepted")
+        .filter(players__rating__isnull=False)
+        .exclude(type="chapter")
+        .exclude(type="e-journal")
+        .exclude(type="library")
+        .exclude(type="institution")
+        .values(
+            "member_id",
+            "chapter_id",
+            "chapters__member_id",
+            "chapters__name",
+            "full_name",
+            "type",
+            "players__rating",
+            "state",
+            "players__sigma",
+        )
+        .order_by("-players__rating")
+    )
+    list_all_players_columns = (
+        {"name": "Name", "attrs": None},
+        {"name": "Chapter", "attrs": None},
+        {"name": "State", "attrs": None},
+        {"name": "Type", "attrs": None},
+        {"name": "Rating", "attrs": None},
+        {"name": "Sigma", "attrs": None},
+    )
+
+    list_all_players_with_pagination = agagd_paginator_helper(
+        request, list_all_players_query
+    )
+
+    return render(
+        request,
+        "agagd_core/players_list.html",
+        {
+            "list_all_players_columns": list_all_players_columns,
+            "list_all_players_data": list_all_players_with_pagination,
+            "page_title": "Members Ratings",
         },
     )

--- a/agagd/templates/agagd_core/players_list.html
+++ b/agagd/templates/agagd_core/players_list.html
@@ -12,7 +12,7 @@
                             <tr>
                                 <th scope="col">#</th>
                                 {% for player_column in list_all_players_columns %}
-                                <th scope="col">{{ player_column.name }}</th>
+                                <th scope="col" {% if player_column.attrs %} class="{{ player_column.attrs }}" {% endif %}>{{ player_column.name }}</th>
                                 {% endfor %}
                             </tr>
                         </thead>
@@ -20,7 +20,9 @@
                         <tbody>
                             {% for player_data in list_all_players_data %}
                             <tr>
-                                <th scope="row">{{ forloop.counter0|add:list_all_players_data.start_index }}</th>
+                                <th scope="row">
+                                    {{ forloop.counter0|add:list_all_players_data.start_index }}
+                                </th>
                                 <td>
                                     <a href="/player/{{ player_data.member_id }}">
                                         {{ player_data.full_name }} ({{ player_data.member_id }})
@@ -33,10 +35,16 @@
                                         &#8212;
                                     {% endif %}
                                 </td>
-                                <td>{{ player_data.state }}</td>
-                                <td>{{ player_data.type }}</td>
-                                <td>{{ player_data.players__rating }}</td>
-                                <td>{{ player_data.players__sigma }}</td>
+                                <td class="{{ mobile_column_attrs }}">{{ player_data.state }}</td>
+                                <td class="{{ mobile_column_attrs }}">
+                                    {{ player_data.type }}
+                                </td>
+                                <td>
+                                    {{ player_data.players__rating }}
+                                </td>
+                                <td class="{{ mobile_column_attrs }}">
+                                    {{ player_data.players__sigma }}
+                                </td>
                             </tr>
                             {% endfor %}
                         </tbody>

--- a/agagd/templates/agagd_core/players_list.html
+++ b/agagd/templates/agagd_core/players_list.html
@@ -1,0 +1,73 @@
+{% extends "base.beta.html" %}
+
+{% block content %}
+    <section id="list-all-players-block" class="container">
+        <section class="row">
+            <section class="col-sm-12 col-md-12 col-lg-12">
+                <h5 class="table-headers list-all-players-table-headers">Members Ratings</h5>
+
+                <div class="list-all-players-table">
+                    <table class="table">
+                        <thead class="thead-dark">
+                            <tr>
+                                <th scope="col">#</th>
+                                {% for player_column in list_all_players_columns %}
+                                <th scope="col">{{ player_column.name }}</th>
+                                {% endfor %}
+                            </tr>
+                        </thead>
+
+                        <tbody>
+                            {% for player_data in list_all_players_data %}
+                            <tr>
+                                <th scope="row">{{ forloop.counter0|add:list_all_players_data.start_index }}</th>
+                                <td>
+                                    <a href="/player/{{ player_data.member_id }}">
+                                        {{ player_data.full_name }} ({{ player_data.member_id }})
+                                    </a>
+                                </td>
+                                <td>
+                                    {% if player_data.chapters__name %}
+                                        <a href="/chapter/{{ player_data.chapter_id }}">{{ player_data.chapters__name }}</a>
+                                    {% else %}
+                                        &#8212;
+                                    {% endif %}
+                                </td>
+                                <td>{{ player_data.state }}</td>
+                                <td>{{ player_data.type }}</td>
+                                <td>{{ player_data.players__rating }}</td>
+                                <td>{{ player_data.players__sigma }}</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+
+                    <nav aria-label="Table Page Navigation">
+
+                    {% if list_all_players_data.has_other_pages %}
+                        <ul class="pagination justify-content-center">
+                          {% if list_all_players_data.has_previous %}
+                          <li class="previous page-item">
+                                <a href="?pg={{ list_all_players_data.previous_page_number }}" class="page-link">«</a>
+                          </li>
+                          {% endif %}
+
+                          {% for page_number in list_all_players_data.paginator.page_range %}
+                          <li class="page-item {% if list_all_players_data.number == page_number %} active {% endif %}">
+                            <a href="?pg={{ page_number }}" class="page-link">{{ page_number }}</a>
+                          </li>
+                          {% endfor %}
+
+                          {% if list_all_players_data.has_next %}
+                          <li class="next page-item">
+                                <a href="?pg={{ list_all_players_data.next_page_number }}" class="page-link">»</a>
+                          </li>
+                          {% endif %}
+                        </ul>
+                    {% endif %}
+                    </nav>
+                </div>
+            </section>
+        </section>
+    </section>
+{% endblock %}

--- a/agagd/templates/base.beta.html
+++ b/agagd/templates/base.beta.html
@@ -4,7 +4,15 @@
 
 <html>
   <head>
-    <title>{% block title %} AGAGD | American Go Game Database {% endblock title %}</title>
+    <title>
+    {% block title %}
+        {% if page_title %}
+            {{ "AGAGD | "|add:page_title }}
+        {% else %}
+            AGAGD | American Go Game Database
+        {% endif %}
+    {% endblock title %}
+    </title>
         {% block css %}
             <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css" integrity="sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l" crossorigin="anonymous">
         {% endblock %}

--- a/agagd/templates/base.beta.html
+++ b/agagd/templates/base.beta.html
@@ -10,6 +10,7 @@
         {% endblock %}
 
         {% block js %}
+            <script src="https://unpkg.com/htmx.org@1.3.3" integrity="sha384-QrlPmoLqMVfnV4lzjmvamY0Sv/Am8ca1W7veO++Sp6PiIGixqkD+0xZ955Nc03qO" crossorigin="anonymous"></script>
         {% endblock %}
 
         {% block google_analytics %}

--- a/agagd/templates/base.beta.html
+++ b/agagd/templates/base.beta.html
@@ -67,23 +67,32 @@
             <footer class="footer mx-3">
                 <nav class="footer-nav">
                     {% block footer_nav %}
-                        <h5>Ratings</h5>
-                        <ul class="list-unstyled">
-                            <li>
-                                <a href="/information/">Information</a>
-                            </li>
+                        <section class="container footer-nav-sections">
+                            <section class="row">
+                                <div class="col-12 col-md-3">
+                                    <h5>Ratings</h5>
+                                    <ul class="list-unstyled">
+                                        <li>
+                                            <a href="{% url 'beta:players_list' %}">Members Ratings</a>
+                                        </li>
+                                        <li>
+                                            <a href="/information/">Information</a>
+                                        </li>
 
-                            <li>
-                                <a href="/qualifications/">Qualifications</a>
-                            </li>
-                        </ul>
+                                        <li>
+                                            <a href="/qualifications/">Qualifications</a>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </section>
+                        </section>
                     {% endblock footer_nav %}
                 </nav>
 
                 <section class="footer-copy">
                     {% block footer_copy %}
                         <div class="footer-copyright text-center">&copy; 2020 <a href="https://www.usgo.org">American Go Association</a></div>
-                   {% endblock footer_copy %}
+                    {% endblock footer_copy %}
                 </section>
             </footer>
        </section>

--- a/agagd/templates/base.beta.html
+++ b/agagd/templates/base.beta.html
@@ -18,7 +18,6 @@
         {% endblock %}
 
         {% block js %}
-            <script src="https://unpkg.com/htmx.org@1.3.3" integrity="sha384-QrlPmoLqMVfnV4lzjmvamY0Sv/Am8ca1W7veO++Sp6PiIGixqkD+0xZ955Nc03qO" crossorigin="anonymous"></script>
         {% endblock %}
 
         {% block google_analytics %}


### PR DESCRIPTION
## Summary
Adds a mobile responsive all players to beta without using django_tables2.

### Changes
- Added htmlx to beta.base.html.
- Added beta_url_patters and removed old url format.
- Added players url to url patters and added beta namespace.
- Added beta urls for players list and updated beta url namespace.
- Updated Chapters member_id ForeignKey to correct LEFT OUTER JOIN queries.
- Added list_all_players view.
- Added players_list template for all player ratings.
- Added Dymaic Title and Default Title to Beta Base.
- Added List All Players to Ratings Footer Nav and Added Section.
- Removed htmlx, for now.
- Added Some Mobile Column Attrs.
