### PR TITLE
update chapters model

### DIFF
--- a/agagd/agagd_core/models.py
+++ b/agagd/agagd_core/models.py
@@ -11,7 +11,7 @@ from django.db import models
 
 
 class Member(models.Model):
-    member_id = models.AutoField(primary_key=True)
+    member_id = models.AutoField(primary_key=True, unique=True)
     legacy_id = models.IntegerField(blank=True)
     full_name = models.CharField(max_length=255, blank=True, db_index=True)
     given_names = models.CharField(max_length=255, blank=True)
@@ -23,13 +23,20 @@ class Member(models.Model):
     region = models.CharField(max_length=255, blank=True)
     country = models.CharField(max_length=255)
     chapter = models.CharField(max_length=100, blank=True)
-    chapter_id = models.IntegerField(blank=True)
     occupation = models.CharField(max_length=100, blank=True)
     citizen = models.SmallIntegerField()
     password = models.CharField(max_length=255, blank=True)
     last_changed = models.DateTimeField(null=True, blank=True)
     renewal_due = models.CharField(max_length=255, blank=True)
     type = models.CharField(max_length=255, blank=True)
+
+    chapter_id = models.ForeignKey(
+        "Chapters",
+        blank=True,
+        db_column="chapter_id",
+        to_field="member_id",
+        on_delete=models.DO_NOTHING,
+    )
 
     def __str__(self):
         return "{0} ({1})".format(self.full_name, self.member_id)
@@ -43,14 +50,7 @@ class Member(models.Model):
 
 class Chapters(models.Model):
     # The member_id for a chapter is the same in this table and in the chapter's corresponding Member object.
-    member_id = models.ForeignKey(
-        "Member",
-        db_column="member_id",
-        to_field="chapter_id",
-        unique=True,
-        primary_key=True,
-        on_delete=models.DO_NOTHING,
-    )
+    member_id = models.IntegerField(unique=True, primary_key=True)
 
     name = models.CharField(max_length=255, blank=True)
     legacy_status = models.CharField(max_length=1, blank=True)
@@ -238,8 +238,8 @@ class Game(models.Model):
 
 # Updated Rating Information Table for Players.
 class Players(models.Model):
-    pin_player = models.ForeignKey(
-        Member, db_column="Pin_Player", primary_key=True, on_delete=models.DO_NOTHING
+    pin_player = models.OneToOneField(
+        "Member", db_column="Pin_Player", primary_key=True, on_delete=models.DO_NOTHING
     )
 
     # Member Name Fields

--- a/agagd/agagd_core/views/beta.py
+++ b/agagd/agagd_core/views/beta.py
@@ -9,7 +9,7 @@ import agagd_core.tables.beta as agagd_tables
 
 # Django Imports
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
-from django.db.models import F, Prefetch, Q
+from django.db.models import F, Q
 from django.shortcuts import get_object_or_404, redirect, render
 
 # Django Table Imports
@@ -71,18 +71,17 @@ def index(request):
 
 def list_all_players(request):
     list_all_players_query = (
-        agagd_models.Member.objects.select_related("chapters")
+        agagd_models.Member.objects.select_related("chapter_id")
         .filter(status="accepted")
         .filter(players__rating__isnull=False)
-        .exclude(type="chapter")
-        .exclude(type="e-journal")
-        .exclude(type="library")
-        .exclude(type="institution")
+        .exclude(type__iexact="e-journal")
+        .exclude(type__iexact="chapter")
+        .exclude(type__iexact="library")
+        .exclude(type__iexact="institution")
         .values(
-            "member_id",
             "chapter_id",
-            "chapters__member_id",
-            "chapters__name",
+            "member_id",
+            "chapter_id__name",
             "full_name",
             "type",
             "players__rating",

--- a/agagd/agagd_core/views/core.py
+++ b/agagd/agagd_core/views/core.py
@@ -152,7 +152,7 @@ def member_detail(request, member_id):
     player = Member.objects.get(member_id=member_id)
 
     try:
-        chapter = Chapters.objects.get(member_id=player.chapter_id)
+        chapter = Chapters.objects.get(member_id=player.chapter_id.member_id)
     except exceptions.ObjectDoesNotExist:
         chapter = None
 

--- a/agagd/agagd_core/views/core.py
+++ b/agagd/agagd_core/views/core.py
@@ -322,22 +322,20 @@ def country_detail(request, country_name):
 
 def all_player_ratings(request):
     all_player_ratings_query = (
-        Member.objects.filter(
-            Q(chapter_id=F("chapters__member_id")) | Q(chapters__member_id__isnull=True)
-        )
-        .filter(Q(member_id=F("players__pin_player")))
+        Member.objects.select_related("chapter_id")
         .filter(status="accepted")
-        .exclude(players__rating__isnull=True)
-        .exclude(type="chapter")
-        .exclude(type="e-journal")
-        .exclude(type="library")
-        .exclude(type="institution")
+        .filter(players__rating__isnull=False)
+        .exclude(type__iexact="e-journal")
+        .exclude(type__iexact="chapter")
+        .exclude(type__iexact="library")
+        .exclude(type__iexact="institution")
         .values(
-            "full_name",
+            "chapter_id",
             "member_id",
+            "chapter_id__name",
+            "full_name",
             "type",
             "players__rating",
-            "chapter_id",
             "state",
             "players__sigma",
         )

--- a/agagd/templates/agagd_core/players_list.html
+++ b/agagd/templates/agagd_core/players_list.html
@@ -29,8 +29,8 @@
                                     </a>
                                 </td>
                                 <td>
-                                    {% if player_data.chapters__name %}
-                                        <a href="/chapter/{{ player_data.chapter_id }}">{{ player_data.chapters__name }}</a>
+                                    {% if player_data.chapter_id__name %}
+                                        <a href="/chapter/{{ player_data.chapter_id }}">{{ player_data.chapter_id__name }}</a>
                                     {% else %}
                                         &#8212;
                                     {% endif %}
@@ -61,9 +61,11 @@
                           {% endif %}
 
                           {% for page_number in list_all_players_data.paginator.page_range %}
-                          <li class="page-item {% if list_all_players_data.number == page_number %} active {% endif %}">
-                            <a href="?pg={{ page_number }}" class="page-link">{{ page_number }}</a>
-                          </li>
+                                {% if page_number > list_all_players_data.number|add:'-5' and page_number < list_all_players_data.number|add:'5' %}
+                                <li class="page-item {% if list_all_players_data.number == page_number %} active {% endif %}">
+                                    <a href="?pg={{ page_number }}" class="page-link">{{ page_number }}</a>
+                                </li>
+                                {% endif %}
                           {% endfor %}
 
                           {% if list_all_players_data.has_next %}


### PR DESCRIPTION
## Summary
This corrects the ManyToOne relationship between Member and Chapters. That is
there are many of Member with one Chapter not many of chapters and one Member.

## Changes 
- Updated the Chapters Model to ManyToOne from Members.
- Updated the Chapters Model to ManyToOne from Members.
- Added new query fields to template for chapter_id.

## Notes
- There are other warnings that are fixed as well.
- Mainly to maintain some of the legacy features and update with new Member model.