### PR TITLE
Added Markdown Linter

### DIFF
--- a/.agagd_mdlrc_style.rb
+++ b/.agagd_mdlrc_style.rb
@@ -17,3 +17,6 @@ exclude_rule 'MD013'
 
 ## Bare URL
 exclude_rule 'MD034'
+
+## Turning the Output Required Off for now.
+exclude_rule 'MD014'

--- a/.agagd_mdlrc_style.rb
+++ b/.agagd_mdlrc_style.rb
@@ -1,0 +1,11 @@
+## Include All Styles
+## https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md
+all
+
+## General Markdown Exclusions
+
+## Line Length
+exclude_rule 'MD013'
+
+## Bare URL
+exclude_rule 'MD034'

--- a/.agagd_mdlrc_style.rb
+++ b/.agagd_mdlrc_style.rb
@@ -2,7 +2,15 @@
 ## https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md
 all
 
+## Set Some Rules
+rule 'MD026', punctuation: ',:;'
+
 ## General Markdown Exclusions
+
+## First Line in file should be a top level header
+## Breaks on Github Issue Templates
+exclude_rule 'MD002'
+exclude_rule 'MD041'
 
 ## Line Length
 exclude_rule 'MD013'

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -8,33 +8,41 @@ assignees: ''
 ---
 
 ## Summary of the Bug
+
 A clear and concise description of what the bug is.
 
 ## Steps to Reproduce the Behaviour
+
 **i.e.,**
+
 1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+1. Click on '....'
+1. Scroll down to '....'
+1. See error
 
 ## The Expected Behaviour
+
 Concise description of what you expected to happen.
 
 ## Screenshots
+
 If applicable, add screenshots to help explain your problem.
 
 ## Hardware and Software Information
 
 ### Desktop
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
 
 ### Smartphone
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
 
 ## Notes
+
 Add any other information about the bug which you thing may be helpful.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,10 +8,13 @@ assignees: ''
 ---
 
 ## Is your feature request related to a problem?
+
 A clear and concise description of what you would like to see added to the AGAGD.
 
 ## Describe the feature you'd like to see on the AGAGD.
+
 A clear and concise description of the feature you would like to see.
 
 ## Notes
+
 Add any other information or screenshots about the feature request here.

--- a/.mdlrc
+++ b/.mdlrc
@@ -1,0 +1,1 @@
+style '.agagd_mdlrc_style.rb'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,7 @@ repos:
     hooks:
       - id: isort
         args: ["--profile", "black", "--filter-files"]
+  - repo: https://github.com/jumanjihouse/pre-commit-hooks
+    rev: 2.1.5
+    hooks:
+      - id: markdownlint

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ## AGAGD - the American Go Association Games Database
 
 The AGAGD is a django web application ported from the EuroGo Games Database to Python that provides:
+
 * member information,
 * top tournaments listings,
 * top players listings,
@@ -16,10 +17,13 @@ We welcome and encourage contributions to the AGAGD with Pull Requests (PRs), fe
 Contributors submitting Pull Requests (PRs) will require a `schema.sql` file within their local AGAGD repository. The `schema.sql` can be found in [USGO SQL Schema's Repo](https://github.com/usgo/usgo-sql-schemas).
 
 ## Project Priorities
+
 [Bug Triage](https://github.com/usgo/agagd/projects/1) project for the AGAGD which lists and organizes current priorites the AGA Development Team has for the AGAGD.
 
 ## Additional Documentation
+
 * [/docs](/docs)
 
 ## License
+
 The AGAGD is licensed under the MIT License which can be found in [LICENSE](/LICENSEE).

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -4,7 +4,6 @@
 
 Docker can automate much of the configuration for you.
 
-
 ## Using docker
 
 ### Prerequisites
@@ -20,7 +19,7 @@ These values will be used by both the database and the app. Now, run either:
 
 #### For Python 2.7
 
-~~~
+~~~shell
 $ docker-compose up --build
 ~~~
 
@@ -28,14 +27,13 @@ $ docker-compose up --build
 
 ##### Note: Python 3.7+ is not fully supported by the AGAGD Application. More information can be found in issue #112.
 
-~~~
+~~~shell
 $ docker-compose -f docker-compose-python3.yml up --build
 ~~~
 
 Wait for the database to initialize and the app to start up. (there will be something like `spawned uWSGI worker` in the logs)
 
 You should now be serving the app at http://localhost:8000.
-
 
 ### Caveats
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,20 +1,23 @@
 # AGAGD
 
 ## Overview
+
 An app to display users, games, tournaments, and ratings information on the AGA website.
 The AGAGD is a port of the old EuroGO Games Database to python developed for the [American Go Association (AGA)](usgo.org).
 
 ## Development
 
 ### Code Style
+
 The AGAGD project uses pre-commit for some basic linting and mostly follows [black](https://github.com/psf/black), so before it is required to have pre-commit installed and any errors fixed before making a pull request. ([Pre Commit](https://pre-commit.com/), [DJango Code Style](https://docs.djangoproject.com/en/3.2/internals/contributing/writing-code/coding-style/))
 
 #### Install pre-commit
-* `shell> pip3 install pre-commit`
-* `shell> pre-commit install`
+
+* `$ pip3 install pre-commit`
+* `$ pre-commit install`
 
 ### Getting started
 
-**Important: running the agagd locally now requires the `schema.sql` which can be found in [USGO SQL Schema's Repo](https://github.com/usgo/usgo-sql-schemas). The` schema.sql` file needs to be place in the main directory of the locally cloned AGAGD repo.**
+**Important: running the agagd locally now requires the `schema.sql` which can be found in [USGO SQL Schema's Repo](https://github.com/usgo/usgo-sql-schemas). The `schema.sql` file needs to be place in the main directory of the locally cloned AGAGD repo.**
 
 The AGAGD application uses docker for local development. Information about how to get up and running see [docker.md](docker.md) for details.


### PR DESCRIPTION
## Summary

Change Adds the pre-commit hook markdownlint which is
a ruby based linter for markdown. (https://github.com/markdownlint/markdownlint/blob/master/docs/configuration.md) The style guide can be found on https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md.
