### PR TITLE
feat: add testing with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,3 +44,4 @@ ENV TEMPLATE_DIR=/srv/templates
 COPY --chown=django:django scripts/ agagd/ /srv/
 
 ENTRYPOINT ["/srv/entrypoint.sh"]
+CMD ["gunicorn", "-b", "0.0.0.0:8000", "agagd.wsgi"]

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -11,11 +11,11 @@
 version: '3.5'
 
 services:
-  app:
+  test_app:
     build: ./
     restart: always
     environment:
-      DB_HOST: db
+      DB_HOST: test_db
       DB_PORT: 3306
       APP_DB_NAME: agagd
       AGAGD_USER: agagd
@@ -30,15 +30,16 @@ services:
       - ./agagd/static:/srv/static
       - ./agagd/jinja2:/srv/jinja2
       - ./agagd/templates:/srv/templates
+    command: "python manage.py test"
     depends_on:
-      - "db"
-  db:
+      - "test_db"
+  test_db:
     build:
       context: ./
       dockerfile: Dockerfile.mysql
     restart: always
     volumes:
-      - database:/var/lib/mysql
+      - test_database:/var/lib/mysql
     environment:
       # This is safer than it looks, since without a 'ports' section, docker-compose
       # isolates this app to a network local to this compose file.
@@ -49,4 +50,4 @@ services:
       MYSQL_PASSWORD: "${MYSQL_PASSWORD}"
 
 volumes:
-  database:
+  test_database:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,52 @@
+# docker-compose setup for a development environment.
+# To use this file, populate config-docker.env with the following:
+#
+# MYSQL_PASSWORD - a password for the mysql user
+# MYSQL_ROOT_PASSWORD - a password for the mysql *root* user
+#
+# Then you can run:
+#   - docker-compose build
+#   - docker-compose up
+
+version: '3.5'
+
+services:
+  app:
+    build: ./
+    restart: always
+    environment:
+      DB_HOST: db
+      DB_PORT: 3306
+      APP_DB_NAME: agagd
+      AGAGD_USER: agagd
+      MYSQL_PASSWORD: "${MYSQL_PASSWORD}"
+      SECRET_KEY: insecure-key-for-testing
+      DEBUG: "true"
+      LOAD_FIXTURES: "false"
+    volumes:
+      - ./agagd/agagd:/srv/agagd
+      - ./agagd/agagd_core:/srv/agagd_core
+      - ./agagd/media:/srv/media
+      - ./agagd/static:/srv/static
+      - ./agagd/jinja2:/srv/jinja2
+      - ./agagd/templates:/srv/templates
+    depends_on:
+      - "db"
+  db:
+    build:
+      context: ./
+      dockerfile: Dockerfile.mysql
+    restart: always
+    volumes:
+      - database:/var/lib/mysql
+    environment:
+      # This is safer than it looks, since without a 'ports' section, docker-compose
+      # isolates this app to a network local to this compose file.
+      MYSQL_ROOT_HOST: "%"
+      MYSQL_ROOT_PASSWORD: "${MYSQL_ROOT_PASSWORD}"
+      MYSQL_USER: agagd
+      MYSQL_DATABASE: test_agagd
+      MYSQL_PASSWORD: "${MYSQL_PASSWORD}"
+
+volumes:
+  database:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,9 @@ services:
       - ./agagd/static:/srv/static
       - ./agagd/jinja2:/srv/jinja2
       - ./agagd/templates:/srv/templates
-    command: "-r" # Initializes python-autoreload for uwsgi via the scripts/entrypoint.sh.
+    command: "python manage.py runserver 0.0.0.0:8000"
+    depends_on:
+      - "db"
   db:
     build:
       context: ./

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -26,7 +26,7 @@ function wait_for_db() {
     exit 1
 }
 
-if [ "$3" != "test" ]; then
+if [[ "$3" != "test" ]]; then
   wait_for_db
 fi
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -26,7 +26,9 @@ function wait_for_db() {
     exit 1
 }
 
-wait_for_db
+if [ "$3" != "test" ]; then
+  wait_for_db
+fi
 
 if $LOAD_FIXTURES == "true"; then
     python make_fake_fixtures.py 1000 1000 1000 > /tmp/fake_agagd_data.json


### PR DESCRIPTION
- feat: added CMD default for Dockerfile.
- feat: added local development command to docker-compose.yml.
- feat: clean up entrypoint. add loud fail to entrypoint.sh.
- feat: add basic setup for running tests from within docker-compose.yml.
