### PR TITLE
fix: corrected error for search redirect

### DIFF
--- a/agagd/agagd_core/views/search.py
+++ b/agagd/agagd_core/views/search.py
@@ -20,7 +20,7 @@ class SearchView(DetailView):
 
         if query.isdigit():
             member_id = [int(query)]
-            return HttpResponseRedirect(reverse("member_detail", args=member_id))
+            return HttpResponseRedirect(reverse("players_profile", args=member_id))
 
         member_table_data = (
             Member.objects.filter(Q(member_id=F("players__pin_player")))


### PR DESCRIPTION
# Summary

An issue which resulted in an error page when entering an integer
from the search. This would result in no member profile page
appearing.

This issue had been forwarded to @neagle by one of our AGAGD users.
