### PR TITLE
build: Update version of jinja2 from 2.11.3 to 3.0.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ django-admin-tools==0.4.1
 django-debug-toolbar==3.2.1
 django-tables2==2.3.0
 django-extensions==3.1.3
-jinja2==2.11.3
+jinja2==3.0.3
 PyMySQL==1.0.2
 yolk==0.4.3
 gunicorn==20.1.0


### PR DESCRIPTION
Version 2.11.3 of jinja2 uses soft_unicode from MarkupSafe, which is no longer included in the current version of MarkupSafe.  Listing version 2.0.1 of MarkupSafe in this file works, as does updating jinja2 to the most recent version of 3.0.3.