### PR TITLE
fix:  fix black pre-commit hook import error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 19.3b0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort

--- a/agagd/agagd_core/jinga2.py
+++ b/agagd/agagd_core/jinga2.py
@@ -7,9 +7,9 @@ from jinja2 import Environment
 
 def get_members_name_and_id(value):
     """
-        Provides jinja2 custom filter which returns
-        the members information as
-        "[member's full name] (member_id)".
+    Provides jinja2 custom filter which returns
+    the members information as
+    "[member's full name] (member_id)".
     """
     try:
         member = agagd_models.Member.objects.values("full_name", "member_id").get(

--- a/agagd/agagd_core/tables/core.py
+++ b/agagd/agagd_core/tables/core.py
@@ -65,7 +65,7 @@ class ChapterColumn(tables.Column):
                 "<a href='{}'>{}</a>".format(chapter_url, chapter_name)
             )
         except:
-            chapter_html = u"\u2014"
+            chapter_html = "\u2014"
 
         return chapter_html
 

--- a/agagd/agagd_core/views/players_profile.py
+++ b/agagd/agagd_core/views/players_profile.py
@@ -60,7 +60,7 @@ class PlayersProfilePageView(DetailView):
                 game_date = None
 
                 # Check for 0000-00-00 dates
-                if game.game_date != u"0000-00-00":
+                if game.game_date != "0000-00-00":
                     game_date = game.game_date
 
                 t_dat["date"] = t_dat.get("date", game_date)


### PR DESCRIPTION
Problem:  Older versions of `black` were (for some reason) importing
internal modules from the `click` package.  Recent internal updates to
the `click` package now cause `black` to fail (see
https://github.com/psf/black/issues/2964).

Solution:  Two approaches exist.  Either fix the version of `click` to a
previous version, or update the version of `black`.  This commit updates
the version of `black`, and reruns black on all files.