### PR TITLE
fix: Updating django from 3.1.14 to 3.2.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==3.1.14
+Django==3.2.14
 django-admin-tools==0.4.1
 django-debug-toolbar==3.2.1
 django-tables2==2.3.0


### PR DESCRIPTION
Updating from django 3.1.14 to 3.2.14 I did minimal testing and everything appears to be working. This addresses https://www.djangoproject.com/weblog/2022/jul/04/security-releases/