### PR TITLE
fix: upgrading to django 4.0.6

### DIFF
--- a/agagd/agagd/urls.py
+++ b/agagd/agagd/urls.py
@@ -11,9 +11,7 @@ from agagd_core.views.ratings_overview import RatingsOverviewPageView
 from agagd_core.views.search import SearchView
 from agagd_core.views.tournament_detail import TournamentDetailPageView
 from django.conf import settings
-from django.urls import include, re_path
-from django.conf.urls.static import static
-from django.urls import path, reverse_lazy
+from django.urls import path, reverse_lazy, include, re_path
 from django.views.generic import RedirectView
 
 urlpatterns = [

--- a/agagd/agagd/urls.py
+++ b/agagd/agagd/urls.py
@@ -11,7 +11,7 @@ from agagd_core.views.ratings_overview import RatingsOverviewPageView
 from agagd_core.views.search import SearchView
 from agagd_core.views.tournament_detail import TournamentDetailPageView
 from django.conf import settings
-from django.conf.urls import include, url
+from django.urls import include, re_path
 from django.conf.urls.static import static
 from django.urls import path, reverse_lazy
 from django.views.generic import RedirectView
@@ -64,7 +64,7 @@ urlpatterns = [
         TournamentDetailPageView.as_view(),
         name="tournament_detail",
     ),
-    url(r".php$", RedirectView.as_view(url=reverse_lazy("index"))),
+    re_path(r".php$", RedirectView.as_view(url=reverse_lazy("index"))),
 ]
 
 # DebugToolbar URL Configuration

--- a/agagd/agagd/urls.py
+++ b/agagd/agagd/urls.py
@@ -18,50 +18,18 @@ urlpatterns = [
     path("", FrontPageView.as_view(), name="frontpage_view"),
     path("api/games/count/daily/", ApiGameCountView.as_view(), name="game_stats"),
     path("api/status/", ApiStatusView.as_view(), name="api_status_view"),
-    path(
-        "api/ratings/<int:player_id>/<int:time_period>/",
-        ApiPlayerRatings.as_view(),
-        name="member_ratings",
-    ),
+    path("api/ratings/<int:player_id>/<int:time_period>/", ApiPlayerRatings.as_view(),name="member_ratings"),
     path("chapters/", AllChaptersPageView.as_view(), name="all_chapters_page_view"),
-    path(
-        "chapter/<int:chapter_id>/",
-        ChaptersProfilePageView.as_view(),
-        name="chapter_detail",
-    ),
-    path(
-        "chapter/<str:chapter_code>/",
-        agagd_views.chapter_code_redirect,
-        name="chapter_code_redirect",
-    ),
+    path("chapter/<int:chapter_id>/",ChaptersProfilePageView.as_view(),name="chapter_detail"),
+    path("chapter/<str:chapter_code>/", agagd_views.chapter_code_redirect, name="chapter_code_redirect"),
     path("players/", AllPlayersPageView.as_view(), name="players_list"),
-    path(
-        "player/<int:player_id>/",
-        PlayersProfilePageView.as_view(),
-        name="players_profile",
-    ),
-    path(
-        "ratings/overview/",
-        RatingsOverviewPageView.as_view(),
-        name="ratings_overview_page_view",
-    ),
-    path(
-        "ratings/qualifications/",
-        QualificationsPageView.as_view(),
-        name="qualifications_page_view",
-    ),
+    path("player/<int:player_id>/", PlayersProfilePageView.as_view(), name="players_profile"),
+    path("ratings/overview/", RatingsOverviewPageView.as_view(), name="ratings_overview_page_view"),
+    path("ratings/qualifications/", QualificationsPageView.as_view(), name="qualifications_page_view"),
     path("search/", SearchView.as_view(), name="search"),
     path("search/q<str:query>/", SearchView.as_view(), name="search"),
-    path(
-        "tournaments/",
-        AllTournamentsPageView.as_view(),
-        name="all_tournaments_page_view",
-    ),
-    path(
-        "tournament/<slug:code>/",
-        TournamentDetailPageView.as_view(),
-        name="tournament_detail",
-    ),
+    path("tournaments/", AllTournamentsPageView.as_view(), name="all_tournaments_page_view"),
+    path("tournament/<slug:code>/", TournamentDetailPageView.as_view(), name="tournament_detail"),
     re_path(r".php$", RedirectView.as_view(url=reverse_lazy("index"))),
 ]
 

--- a/agagd/agagd_core/models.py
+++ b/agagd/agagd_core/models.py
@@ -260,6 +260,10 @@ class Players(models.Model):
 
 
 class Rating(models.Model):
+
+    # Sets a primary key.
+    id = models.BigAutoField(primary_key=True)
+
     # ForeignKey for the Members
     pin_player = models.ForeignKey(
         Member,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==3.2.14
+Django==4.0.6
 django-admin-tools==0.4.1
 django-debug-toolbar==3.2.1
 django-tables2==2.3.0


### PR DESCRIPTION
This updates the codebase to django 4.0.6. 

The only change needed was due to django.conf.urls.url() being deprecated in 3.0 and removed in 4.0. django.url,re_path() can be used here as a drop-in replacement. 

I also removed django.conf.urls.static.static() as it was unused. 

I tested locally, and everything appears to be working as intended. 

I set a primary key type to ratings to avoid future issues. 

I rewrote the urls.py for consistency purposes. 

